### PR TITLE
remove namePrefix to avoid redundancy in controller name

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,13 +1,6 @@
 # Adds namespace to all resources.
 namespace: application-service-system
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: application-service-
-
 resources:
 - manager.yaml
 


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Removes the prefix from the controller name which results in duplication  `application-service-application-service-controller-manager` when controller is deployed 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

related to https://issues.redhat.com/browse/DEVHAS-272.  Need to specify the app name in the service monitor and would like to keep it readable.

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
